### PR TITLE
Install borg using pip

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "docker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "conventionalCommits.scopes": [
-        "docker"
+        "docs"
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,10 @@ ARG LINUX_HEADERS_VERSION
 # Add author and github link to image metadata
 LABEL org.opencontainers.image.authors="André Büsgen <andre.buesgen@posteo.de>"
 LABEL org.opencontainers.image.source="https://github.com/AnotherStranger/docker-borg-backup"
+LABEL org.opencontainers.image.url="https://github.com/AnotherStranger/docker-borg-backup"
+LABEL org.opencontainers.image.documentation="https://github.com/AnotherStranger/docker-borg-backup"
+LABEL org.opencontainers.image.description="A dockerized borgbackup server"
+LABEL org.opencontainers.image.title="borg-server"
 
 # Define supported Environment variables
 ENV BORG_SERVE_ADDITIONAL_ARGS=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,117 @@
-FROM alpine:3
-
-# Pin package Versions
-ARG BORGBACKUP_VERSION="1.2.2-r1"
+################################################################################
+#                             PIN PACKAGE VERSIONS                             #
+################################################################################
+ARG BORGBACKUP_VERSION="1.2.3"
+ARG PYTHON_VERSION="3.10"
 ARG OPENSSH_VERSION="9.1_p1-r2"
 ARG SED_VERSION="4.9-r0"
 ARG BASH_VERSION="5.2.15-r0"
 ARG SHADOW_VERSION="4.13-r0"
 ARG OPENSSL_VERSION="3.0.8-r0"
+ARG PKG_CONF_VERSION="1.9.4-r0"
+ARG GCC_VERSION="12.2.1_git20220924-r4"
+ARG MUSL_VERSION="1.2.3-r4"
+ARG ACL_VERSION="2.3.1-r1"
+ARG OPENSSL_VERSION="3.0.8-r0"
+ARG XXHASH_VERSION="0.8.1-r0"
+ARG ZSTD_VERSION="1.5.2-r9"
+ARG LZ4_VERSION="1.9.4-r1"
+ARG LINUX_HEADERS_VERSION="5.19.5-r0"
+
+################################################################################
+#                    BUILD BORGBACKUP FROM SOURCE USING PIP                    #
+################################################################################
+FROM python:"${PYTHON_VERSION}"-alpine as builder
+
+# Re-define needed ARGS
+ARG BORGBACKUP_VERSION
+ARG PKG_CONF_VERSION
+ARG OPENSSL_VERSION
+ARG GCC_VERSION
+ARG MUSL_VERSION
+ARG ACL_VERSION
+ARG XXHASH_VERSION
+ARG ZSTD_VERSION
+ARG LZ4_VERSION
+ARG LINUX_HEADERS_VERSION
+
+RUN set -x && \
+    apk add --no-cache \
+        pkgconf="${PKG_CONF_VERSION}" \
+        openssl-dev="${OPENSSL_VERSION}" \
+        gcc="${GCC_VERSION}" \
+        musl-dev="${MUSL_VERSION}" \
+        acl-dev="${ACL_VERSION}" \
+        zstd-dev="${ZSTD_VERSION}" \
+        lz4-dev="${LZ4_VERSION}" \
+        xxhash-dev="${XXHASH_VERSION}" \
+        linux-headers="${LINUX_HEADERS_VERSION}" \
+    && mkdir /wheel \
+    && pip wheel borgbackup=="${BORGBACKUP_VERSION}" -w /wheel
+
+
+################################################################################
+#                INSTALL BUILT BORGBACKUP PACKAGE IN NEW STAGE                 #
+################################################################################
+FROM python:"${PYTHON_VERSION}"-alpine as runtime-image
+
+# Re-define needed ARGS
+ARG OPENSSH_VERSION
+ARG SED_VERSION
+ARG BASH_VERSION
+ARG SHADOW_VERSION
+ARG OPENSSL_VERSION
+ARG XXHASH_VERSION
+ARG ZSTD_VERSION
+ARG LZ4_VERSION
+ARG ACL_VERSION
+ARG LINUX_HEADERS_VERSION
 
 # Add author and github link to image metadata
 LABEL org.opencontainers.image.authors="André Büsgen <andre.buesgen@posteo.de>"
 LABEL org.opencontainers.image.source="https://github.com/AnotherStranger/docker-borg-backup"
 
+# Define supported Environment variables
 ENV BORG_SERVE_ADDITIONAL_ARGS=""
 ENV BORG_UID=""
 ENV BORG_GID=""
 ENV BORG_AUTHORIZED_KEYS=""
 
-RUN set -x \
-    && apk add --no-cache borgbackup="${BORGBACKUP_VERSION}" openssh-server="${OPENSSH_VERSION}" sed="${SED_VERSION}" bash="${BASH_VERSION}" shadow="${SHADOW_VERSION}" openssl="${OPENSSL_VERSION}"\
-    && adduser -D -u 500 borg borg  \
+RUN set -x && \
+    apk add --no-cache \
+        openssh-server="${OPENSSH_VERSION}" \
+        sed="${SED_VERSION}" \
+        bash="${BASH_VERSION}" \
+        shadow="${SHADOW_VERSION}" \
+        openssl="${OPENSSL_VERSION}" \
+        xxhash="${XXHASH_VERSION}" xxhash-dev="${XXHASH_VERSION}" \
+        acl="${ACL_VERSION}" acl-dev="${ACL_VERSION}" \
+        zstd="${ZSTD_VERSION}" zstd-dev="${ZSTD_VERSION}" \
+        lz4="${LZ4_VERSION}" lz4-dev="${LZ4_VERSION}" \
+        linux-headers="${LINUX_HEADERS_VERSION}" \
+    && adduser -D -u 500 borg borg \
     && mkdir -p /var/run/sshd /var/backups/borg /var/lib/docker-borg/ssh \
     && mkdir /home/borg/.ssh \
     && chown borg:borg /home/borg/.ssh \
     && chmod 700 /home/borg/.ssh
 
+COPY --from=builder /wheel /wheel
+RUN pip --no-cache-dir install /wheel/*.whl
 
+# Configure SSH
 RUN set -x \
     && sed -i \
         -e 's/^#PasswordAuthentication yes$/PasswordAuthentication no/g' \
         -e 's/^PermitRootLogin without-password$/PermitRootLogin no/g' \
         -e 's/^X11Forwarding yes$/X11Forwarding no/g' \
         -e 's/^#LogLevel .*$/LogLevel ERROR/g' \
-        /etc/ssh/sshd_config
+        /etc/ssh/sshd_config \
+&& mkdir -p /var/lib/docker-borg/ssh \
+&& mkdir -p /home/borg/backups
 
 VOLUME ["/home/borg/backups/", "/var/lib/docker-borg"]
 
 COPY ./entrypoint.sh /
-
 
 EXPOSE 22
 CMD ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: borg
 
-    image: horaceworblehat/borg-server
+    #image: horaceworblehat/borg-server
     environment:
       # Specify you public ssh keys here. Separate keys by adding \n
-      BORG_AUTHORIZED_KEYS: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM7/8kuSuApH3ABTZxrSgOhjVqByfosFw7BtIWTFgW6N andre@andre-work\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOvM7aEEYbgjlakMkJd6pziDGpz1BpN1uGpiEX4+gw2w buesgen@fh-aachen.de\nssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCUgn8KhUK031Ac1O88U/ZpEam2++lW7trRM4CpiV3/ZBOY7/zdHaElsb1/2h5gOaczlTKsMznpecbQNDVEf7ik0L1f2M/TLSuaXrOoSB7m2Tw2wHDfVZe/go+HJxAHTu5ppmluOrzIMf6frgeybtCpZsx9DRIpirPEgx7xJOa3Up0Av0AqbfwgPabHXIKXFPYSJTp5hNMZICru1mK6FiXtYduhyK8MCAHqXxTu8/d6qeQOPPC7h4+fOZy29KGZmOg2M4hNbaWl6vb/Gh4seufM61cPlKn588Kp7CZ2XbxioN0CwzuYInWKRgXJjuY/ZvxM5+ODvCiQjbwEu9e+v+iz cardno:0005 00006960"
-      BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G"
+      BORG_AUTHORIZED_KEYS: "key_one\nkey_two"
+      BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
       BORG_UID: "1000"
       BORG_GID: "1000"
     volumes:
       - backup:/home/borg/backups
       - server_keys:/var/lib/docker-borg
     ports:
-      - "10022:22"
-    privileged: true
+      - "8022:22"
 
 volumes:
   backup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,19 +5,21 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: borg
 
-    #image: horaceworblehat/borg-server
+    image: horaceworblehat/borg-server
     environment:
       # Specify you public ssh keys here. Separate keys by adding \n
-      BORG_AUTHORIZED_KEYS: "key_one\nkey_two"
-      BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
+      BORG_AUTHORIZED_KEYS: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM7/8kuSuApH3ABTZxrSgOhjVqByfosFw7BtIWTFgW6N andre@andre-work\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOvM7aEEYbgjlakMkJd6pziDGpz1BpN1uGpiEX4+gw2w buesgen@fh-aachen.de\nssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCUgn8KhUK031Ac1O88U/ZpEam2++lW7trRM4CpiV3/ZBOY7/zdHaElsb1/2h5gOaczlTKsMznpecbQNDVEf7ik0L1f2M/TLSuaXrOoSB7m2Tw2wHDfVZe/go+HJxAHTu5ppmluOrzIMf6frgeybtCpZsx9DRIpirPEgx7xJOa3Up0Av0AqbfwgPabHXIKXFPYSJTp5hNMZICru1mK6FiXtYduhyK8MCAHqXxTu8/d6qeQOPPC7h4+fOZy29KGZmOg2M4hNbaWl6vb/Gh4seufM61cPlKn588Kp7CZ2XbxioN0CwzuYInWKRgXJjuY/ZvxM5+ODvCiQjbwEu9e+v+iz cardno:0005 00006960"
+      BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G"
       BORG_UID: "1000"
       BORG_GID: "1000"
     volumes:
       - backup:/home/borg/backups
       - server_keys:/var/lib/docker-borg
     ports:
-      - "8022:22"
+      - "10022:22"
+    privileged: true
 
 volumes:
   backup:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 
-echo "Starting borgbackup-server...."
-echo "Environment:"
-echo "   BORG_UID                   = ${BORG_UID}"
-echo "   BORG_GID                   = ${BORG_GID}"
-echo "   BORG_SERVE_ADDITIONAL_ARGS = ${BORG_SERVE_ADDITIONAL_ARGS}"
+echo "################################################################################"
+echo "#                          STARTING BORGBACKUP-SERVER                          #"
+echo "################################################################################"
 echo ""
 
 mkdir -p /var/lib/docker-borg/ssh >/dev/null 2>&1
-mkdir -p /home/borg/backups
+mkdir -p /home/borg/backups >/dev/null 2>&1
 
 # Create a random password each startup, as only ssh-key auth is allowed
 BORG_PASSWORD=$(openssl passwd -5 "$(openssl rand -base64 128)")
 usermod -p "$BORG_PASSWORD" borg > /dev/null
 usermod -U borg > /dev/null
 
+# Generate SSH host-key, if not present
 if [ ! -f /var/lib/docker-borg/ssh/ssh_host_rsa_key ]; then
     echo "Creating SSH keys. To persist keys across container updates, mount a volume to /var/lib/docker-borg..."
     ssh-keygen -A
@@ -37,11 +36,28 @@ if [ -n "${BORG_AUTHORIZED_KEYS+x}" ]; then
     chown borg:borg /home/borg/.ssh/authorized_keys
     chmod og-rwx /home/borg/.ssh/authorized_keys
 
-    echo "Printing the contents of /home/borg/.ssh/authorized_keys:"
+    echo "################################################################################"
+    echo "#          PRINTING THE CONTENTS OF /HOME/BORG/.SSH/AUTHORIZED_KEYS:           #"
+    echo "################################################################################"
     cat /home/borg/.ssh/authorized_keys
+    echo "end of /home/borg/.ssh/authorized_keys"
+    echo ""
 fi
 
 chown -R borg:borg /home/borg
 chown -R borg:borg /home/borg/.ssh
+
+echo "################################################################################"
+echo "#                    BORGBACKUP SERVER STARTED SUCCESSFULLY                    #"
+echo "################################################################################"
+echo "Environment:"
+echo "   BORG_UID                   = ${BORG_UID}"
+echo "   BORG_GID                   = ${BORG_GID}"
+echo "   BORG_SERVE_ADDITIONAL_ARGS = ${BORG_SERVE_ADDITIONAL_ARGS}"
+echo "Borg Version: $(borg --version)"
+echo "Following borg repos are present:"
+ls -Al /home/borg/backups
+echo "Size of all backups combined: $(du -sh /home/borg/backups)"
+
 
 exec /usr/sbin/sshd -D -e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,8 @@ if [ ! -f /var/lib/docker-borg/ssh/ssh_host_rsa_key ]; then
     ssh-keygen -A
     mv /etc/ssh/ssh*key* /var/lib/docker-borg/ssh/
 fi
+# Ensure correct permisiions for ssh keys
+chmod -R og-rwx /var/lib/docker-borg/ssh/
 
 ln -sf /var/lib/docker-borg/ssh/* /etc/ssh >/dev/null 2>&1
 


### PR DESCRIPTION
The alpine borg image is not up-to-date.
This PR introduces a multistage docker image, which installs borg from source using pip.

Closes #15 