### PR TITLE
fix(ci): :adhesive_bandage: remove duplicate definition of releasenot…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,9 @@ repos:
   rev: v0.33.0
   hooks:
   - id: markdownlint-fix
+    args:
+      - "-i"
+      - "CHANGELOG.md"
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.9.0.2
   hooks:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -105,7 +105,6 @@
     [
       "@semantic-release/github"
     ],
-    "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,10 @@
 # [1.9.0-rc.1](https://github.com/AnotherStranger/docker-borg-backup/compare/v1.8.1...v1.9.0-rc.1) (2023-03-31)
 
-
 ### Features
 
 * **docs:** :memo: add changelog.md generation to repository ([6fce777](https://github.com/AnotherStranger/docker-borg-backup/commit/6fce777c4ac38383102913ff33038f57cee3c8e7))
 
-
-
-
-
 # [1.9.0-rc.1](https://github.com/AnotherStranger/docker-borg-backup/compare/v1.8.1...v1.9.0-rc.1) (2023-03-31)
-
 
 ### Features
 


### PR DESCRIPTION
…es-generator

Thie duplicated definition of the release-notes-generator lead to duplicated changelog entries