### PR TITLE
Improve security and handling around BORG_AUTHORIZED_KEYS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.1.4](https://github.com/AnotherStranger/docker-borg-backup/compare/v2.1.3...v2.1.4) (2023-12-09)
+
+
+### Build System
+
+* **release:** 2.1.4-rc.1 ([c7dc1e2](https://github.com/AnotherStranger/docker-borg-backup/commit/c7dc1e215ecb6d8cdb63842311c7a7f95208eff9))
+* **deps:** update actions/setup-python action to v5 ([13b8b04](https://github.com/AnotherStranger/docker-borg-backup/commit/13b8b04c3fbfa5046a475f6609f14c6aa14fe82b))
+
+
+### Code Refactoring
+
+* **deps:** :arrow_up: update package dependencies ([15f30c4](https://github.com/AnotherStranger/docker-borg-backup/commit/15f30c4855de2dfe5f3f6db974d9e2689a70e5bc))
+
 ## [2.1.4-rc.1](https://github.com/AnotherStranger/docker-borg-backup/compare/v2.1.3...v2.1.4-rc.1) (2023-12-09)
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 # if BORG_AUTHORIZED_KEYS is set substitute authorized_keys file
 if [ -n "${BORG_AUTHORIZED_KEYS+x}" ]; then
-    echo -e "${BORG_AUTHORIZED_KEYS}" | sed  -e "s/^/command=\"borg serve ${BORG_SERVE_ADDITIONAL_ARGS} --restrict-to-path \/home\/borg\/backups\" /"  >/home/borg/.ssh/authorized_keys
+    echo -e "${BORG_AUTHORIZED_KEYS}" | sed -re "/^\\s*(\$|#)/! s/^/restrict,command=\"borg serve ${BORG_SERVE_ADDITIONAL_ARGS} --restrict-to-path \/home\/borg\/backups\" /"  >/home/borg/.ssh/authorized_keys
 fi
 chown borg:borg /home/borg/.ssh/authorized_keys
 chmod og-rwx /home/borg/.ssh/authorized_keys


### PR DESCRIPTION
Adds `restrict` to lock down all extra features on connections. This is what was recommended by borg's documentation.

Ignores empty lines, space/tab filled lines and comment lines. This makes me less guilty for adding documentation.