### PR TITLE
feat(container): :sparkles: Make chown-ing configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ARG LZ4_VERSION="1.9.4-r5"
 # renovate: datasource=repology depName=alpine_3_20/linux-headers versioning=loose
 ARG LINUX_HEADERS_VERSION="6.6-r0"
 
-FROM python:3.12.4-alpine3.20@sha256:0bd77ae937dce9037e136ab35f41eaf9e012cfd741fc3c8dd4b3e2b63499f12c as base
+FROM python:3.12.4-alpine3.20@sha256:0bd77ae937dce9037e136ab35f41eaf9e012cfd741fc3c8dd4b3e2b63499f12c AS base
 
 ################################################################################
 #                    BUILD BORGBACKUP FROM SOURCE USING PIP                    #
@@ -101,7 +101,7 @@ LABEL org.opencontainers.image.title="borg-server"
 ENV BORG_SERVE_ADDITIONAL_ARGS=""
 ENV BORG_UID=""
 ENV BORG_GID=""
-ENV ENUSURE_BACKUP_PERMISSIONS=true
+ENV ENSURE_BACKUP_PERMISSIONS=true
 
 RUN set -x && \
     apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ LABEL org.opencontainers.image.title="borg-server"
 ENV BORG_SERVE_ADDITIONAL_ARGS=""
 ENV BORG_UID=""
 ENV BORG_GID=""
+ENV ENUSURE_BACKUP_PERMISSIONS=true
 
 RUN set -x && \
     apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ services:
       BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
       BORG_UID: "1000" # optional: your user id (run id in bash)
       BORG_GID: "1000" # optional: your group id (run id in bash)
+      ENUSURE_BACKUP_PERMISSIONS: true # optional (default: true) if set to false chown -R borg:borg on your backups will be skipped
     volumes:
       - backup:/home/borg/backups # You can find your backups inside this volume
       - server_keys:/var/lib/docker-borg # This volume is used to persist the hosts ssh-keys across updates
@@ -93,6 +94,7 @@ volumes:
 | `BORG_UID`                   | UID for the backup user.                                                                                                       | `1000`                 |
 | `BORG_GID`                   | GID for the backup user.                                                                                                       | `1000`                 |
 | `BORG_SERVE_ADDITIONAL_ARGS` | Additional CMD args to borg serve                                                                                              | `--append-only`        |
+| `ENUSURE_BACKUP_PERMISSIONS` | If set to false chown -R borg:borg on your backups will be skipped. Default: true.                                             | `false`                |
 <!-- markdownlint-enable -->
 
 ### Important Notes

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ services:
       BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
       BORG_UID: "1000" # optional: your user id (run id in bash)
       BORG_GID: "1000" # optional: your group id (run id in bash)
-      ENUSURE_BACKUP_PERMISSIONS: true # optional (default: true) if set to false chown -R borg:borg on your backups will be skipped
+      ENSURE_BACKUP_PERMISSIONS: true # optional (default: true) if set to false chown -R borg:borg on your backups will be skipped
     volumes:
       - backup:/home/borg/backups # You can find your backups inside this volume
       - server_keys:/var/lib/docker-borg # This volume is used to persist the hosts ssh-keys across updates
@@ -94,7 +94,7 @@ volumes:
 | `BORG_UID`                   | UID for the backup user.                                                                                                       | `1000`                 |
 | `BORG_GID`                   | GID for the backup user.                                                                                                       | `1000`                 |
 | `BORG_SERVE_ADDITIONAL_ARGS` | Additional CMD args to borg serve                                                                                              | `--append-only`        |
-| `ENUSURE_BACKUP_PERMISSIONS` | If set to false chown -R borg:borg on your backups will be skipped. Default: true.                                             | `false`                |
+| `ENSURE_BACKUP_PERMISSIONS` | If set to false chown -R borg:borg on your backups will be skipped. Default: true.                                             | `false`                |
 <!-- markdownlint-enable -->
 
 ### Important Notes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
       BORG_UID: "1000"
       BORG_GID: "1000"
+      ENUSURE_BACKUP_PERMISSIONS: false
     volumes:
       - backup:/home/borg/backups
       - server_keys:/var/lib/docker-borg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
       BORG_UID: "1000"
       BORG_GID: "1000"
-      ENUSURE_BACKUP_PERMISSIONS: false
+      ENUSURE_BACKUP_PERMISSIONS: true
     volumes:
       - backup:/home/borg/backups
       - server_keys:/var/lib/docker-borg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       BORG_SERVE_ADDITIONAL_ARGS: "--storage-quota 900G --append-only"
       BORG_UID: "1000"
       BORG_GID: "1000"
-      ENUSURE_BACKUP_PERMISSIONS: true
+      ENSURE_BACKUP_PERMISSIONS: true
     volumes:
       - backup:/home/borg/backups
       - server_keys:/var/lib/docker-borg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ echo "end of /home/borg/.ssh/authorized_keys"
 echo ""
 
 # chown the backups, can be deactivated by setting ENSURE_BACKUP_PERMISSIONS to false
-if [ "${ENUSURE_BACKUP_PERMISSIONS}" = true ]; then
+if [ "${ENSURE_BACKUP_PERMISSIONS}" = true ]; then
     chown -R borg:borg /home/borg/backups
 else
     echo "I will not ensure the correct permissions, because \$ENSURE_BACKUP_PERMISSIONS is not true."
@@ -65,7 +65,7 @@ echo "Environment:"
 echo "   BORG_UID                   = ${BORG_UID}"
 echo "   BORG_GID                   = ${BORG_GID}"
 echo "   BORG_SERVE_ADDITIONAL_ARGS = ${BORG_SERVE_ADDITIONAL_ARGS}"
-echo "   ENUSURE_BACKUP_PERMISSIONS = ${ENUSURE_BACKUP_PERMISSIONS}"
+echo "   ENSURE_BACKUP_PERMISSIONS = ${ENSURE_BACKUP_PERMISSIONS}"
 echo "Borg Version: $(borg --version)"
 echo "Following borg repos are present:"
 du -sh /home/borg/backups/*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,15 @@ cat /home/borg/.ssh/authorized_keys
 echo "end of /home/borg/.ssh/authorized_keys"
 echo ""
 
-chown -R borg:borg /home/borg
+# chown the backups, can be deactivated by setting ENSURE_BACKUP_PERMISSIONS to false
+if [ "${ENUSURE_BACKUP_PERMISSIONS}" = true ]; then
+    chown -R borg:borg /home/borg/backups
+else
+    echo "I will not ensure the correct permissions, because \$ENSURE_BACKUP_PERMISSIONS is not true."
+    echo ""
+fi
+
+# Ensure that the ssh keys have the correct permissions
 chown -R borg:borg /home/borg/.ssh
 
 echo "################################################################################"
@@ -57,6 +65,7 @@ echo "Environment:"
 echo "   BORG_UID                   = ${BORG_UID}"
 echo "   BORG_GID                   = ${BORG_GID}"
 echo "   BORG_SERVE_ADDITIONAL_ARGS = ${BORG_SERVE_ADDITIONAL_ARGS}"
+echo "   ENUSURE_BACKUP_PERMISSIONS = ${ENUSURE_BACKUP_PERMISSIONS}"
 echo "Borg Version: $(borg --version)"
 echo "Following borg repos are present:"
 du -sh /home/borg/backups/*


### PR DESCRIPTION
The `/home/borg/backups` will be chown'ed on every startup to ensure that the container user has accesss to your backups. However, not every filesystem supports permissions so you may wish to deactivate this step. You can now do so by setting `ENSURE_BACKUP_PERMISSIONS` to false.

Closes #117 